### PR TITLE
use `black <= 21.12b0` (#435)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ minify =
     docker >= 4.4.1
 dev =
     %(minify)s
-    black
+    black <= 21.12b0
     codecov
     flake8
     mypy == 0.790


### PR DESCRIPTION
There was a build error in
https://github.com/ReproNim/neurodocker/pull/434 that was caused by
black requiring click>=8 and neurodocker requiring click<8. I tried
using click 8.x but it caused a problem in the --copy instruction. So
instead I pinned black to a version from december 2021.